### PR TITLE
change PHPDoc @param

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -21,7 +21,7 @@
  * Shortcut to the Nanite::get() method.
  *
  * @param string $route
- * @param function $function
+ * @param mixed Callback $function
  */
 function get($route, $function)
 {
@@ -32,7 +32,7 @@ function get($route, $function)
  * Shortcut to the Nanite::post() method.
  *
  * @param string $route
- * @param function $function
+ * @param mixed Callback $function
  */
 function post($route, $function)
 {
@@ -43,7 +43,7 @@ function post($route, $function)
  * Shortcut to the Nanite::put() method.
  *
  * @param string $route
- * @param function $function
+ * @param mixed Callback $function
  */
 function put($route, $function)
 {
@@ -54,7 +54,7 @@ function put($route, $function)
  * Shortcut to the Nanite::patch() method.
  *
  * @param string $route
- * @param function $function
+ * @param mixed Callback $function
  */
 function patch($route, $function)
 {
@@ -65,7 +65,7 @@ function patch($route, $function)
  * Shortcut to the Nanite::delete() method.
  *
  * @param string $route
- * @param function $function
+ * @param mixed Callback $function
  */
 function delete($route, $function)
 {


### PR DESCRIPTION
change 
 * @param function $function
to
 * @param mixed Callback $function

> Undefined class function
> 
> The inspection can produce two types of warnings:
> Undefined class: Declaration of referenced class is not found in build-in library project files.
> Multiple declarations: this version of IDE *will* have problems with completion, member resolution and inheritance analysis for all classes that have multiple definitions in project files (regardless of includes).